### PR TITLE
Independent features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.gem
+.*.swp
 *.rbc
 .bundle
 .config

--- a/lib/blackbeard/feature_rollout.rb
+++ b/lib/blackbeard/feature_rollout.rb
@@ -1,3 +1,5 @@
+require 'digest'
+
 module Blackbeard
   module FeatureRollout
     def rollout?(context)
@@ -21,7 +23,10 @@ module Blackbeard
       return true if users_rate == 100
 
       user_id = id_to_int(context.user_id)
-      (user_id % 100).between?(1,users_rate)
+      feature_id_hash = Digest::SHA256.hexdigest(@id).to_i(16)
+
+      user_id_xor_feature_id_hash = (user_id % 100)^(feature_id_hash % 100)
+      user_id_xor_feature_id_hash.between?(1,users_rate)
     end
 
     def active_visitor?(context)

--- a/spec/feature_rollout_spec.rb
+++ b/spec/feature_rollout_spec.rb
@@ -29,7 +29,7 @@ module Blackbeard
 
     describe "active_user?" do
       context "with no logged in user" do
-        it "should be true if users_rate is 100" do
+        it "should be false if users_rate is 100" do
           feature.users_rate = 100
           allow(context).to receive(:user).and_return(nil)
           expect(feature.active_user?(context)).to be_falsey
@@ -102,8 +102,9 @@ module Blackbeard
 
     describe "active_segment?" do
       it "should be false if there are no group segments" do
-          expect(feature.active_segment?(context)).to be_falsey
+        expect(feature.active_segment?(context)).to be_falsey
       end
+
       context "with group segments" do
         before :each do
           @group_a = Group.create(:a)

--- a/spec/feature_rollout_spec.rb
+++ b/spec/feature_rollout_spec.rb
@@ -49,24 +49,29 @@ module Blackbeard
           expect(feature.active_user?(context)).to be_truthy
         end
 
-        describe "by user_id modulus" do
-          [212,201,1,113,1008].each do |i|
-            it "should be true" do
-              feature.users_rate = 13
-              allow(context).to receive(:user).and_return(double :id => i)
-              allow(context).to receive(:user_id).and_return(i)
-              expect(feature.active_user?(context)).to be_truthy
-            end
-          end
+        # Currently the way we do incremental rollout is by calulatined 
+        # the user_id mod 100, this has the property of being deterministic, 
+        # but it is not independent.
+        #
+        # If we have two features, feature x and feature y, and each are 
+        # turned on for 50% of our users, then independence implies that 
+        # there should be a 25% chance that any single user sees both 
+        # features x and y. However, since the visibility of the feature 
+        # only depends on user_id, users with an id that is less than 50 
+        # mod 100 will see both x and y.
+        it "should allow statistically indepdendent features" do
+          featureX = Blackbeard::Feature.create('feature x')
+          featureX.users_rate = 50
 
-          [200,231,17,199,1018].each do |i|
-            it "should be true" do
-              feature.users_rate = 13
-              allow(context).to receive(:user).and_return(double :id => i)
-              allow(context).to receive(:user_id).and_return(i)
-              expect(feature.active_user?(context)).to be_falsey
-            end
-          end
+          featureY = Blackbeard::Feature.create('feature y')
+          featureY.users_rate = 50
+
+          user_id = 10
+          allow(context).to receive(:user).and_return(double :id => user_id)
+          allow(context).to receive(:user_id).and_return user_id
+
+          expect(featureX.active_user?(context)).to be_falsey
+          expect(featureY.active_user?(context)).to be_truthy
         end
       end
     end


### PR DESCRIPTION
@robotloveskitten Noticed a problem with feature rollout, it is not possible to test features independently. 

For example, if you have a `feature x` and a `feature y`, and both are rolled out to 50% of our users, then independence implies that any given user should have a 25% probability of seeing both features.

However, since the visibility of a feature that is rolled out to some percentage of our users is determined only by their user_id, some users will see many more features at once. Using the example above, let's see how that might look.

Assume there is a user with user_id = 10, then that user will see `feature x` and `feature y`, however a user with user_id = 58 will not see either features.

In order to solve this and make the feature testing independent, we need a reproducible way to calculate a number in the interval [0, 100) with a uniform distribution. We can make use of the property of the XOR operator, that if A is some random variable and B is a uniform random variable, then XOR(A,B) is a uniform random variable.

A straightforward way to get a uniform distribution over [0,100) would to take the SHA256(feature_id) mod 100, and then XOR that with the user_id. It's entirely deterministic, and it in the example above, user_id = 10 would see feature y, but not feature x:

```ruby
irb(main):009:0> Digest::SHA256.hexdigest('feature x').to_i(16)%100 ^ 10
=> 56
irb(main):010:0> Digest::SHA256.hexdigest('feature y').to_i(16)%100 ^ 10
=> 26
```

I've written spec that checks this case and made it pass, let's discuss this, If we don't need independence, then I understand, but if we do, I think we should use an approach like this.


