### PR TITLE
add a data table under each chart

### DIFF
--- a/dashboard/views/shared/_charts.erb
+++ b/dashboard/views/shared/_charts.erb
@@ -1,11 +1,20 @@
 <script type="text/javascript" src="https://www.google.com/jsapi"></script>
 <script type="text/javascript">
   // Load the Visualization API and the piechart package.
-  google.load('visualization', '1.0', {'packages':['corechart']});
+  google.load('visualization', '1.0', {'packages':['corechart','table']});
+
+  $(function(){
+    $(".toggle_data_table").on("click", function(e){
+      e.preventDefault();
+      $($(this).data("target")).toggle();
+    });
+  });
 </script>
 
 <% charts.each do |chart| %>
   <div id="<%= chart.dom_id %>"></div>
+  <p><a href="#" class="toggle_data_table" data-target="#<%= chart.dom_id %>_table">View/Hide Data Table</a></p>
+  <div id="<%= chart.dom_id %>_table" style="display:none;"></div>
   <script type="text/javascript">
     // Set a callback to run when the Google Visualization API is loaded.
     google.setOnLoadCallback(
@@ -14,7 +23,10 @@
         var options = <%= chart.options.to_json %>;
         var div = document.getElementById('<%= chart.dom_id %>');
         new google.visualization.LineChart(div).draw(data, options);
-    });
 
+        var chartDiv = document.getElementById('<%= chart.dom_id %>_table');
+        var table = new google.visualization.Table(chartDiv);
+        table.draw(data, {showRowNumber: false});
+    });
   </script>
 <% end %>


### PR DESCRIPTION
quick and dirty, but adds values to the charts for a more detailed comparison, and easier export to Excel/Numbers.

![screen shot 2015-04-20 at 9 14 35 pm](https://cloud.githubusercontent.com/assets/16454/7245577/46d3273a-e7a2-11e4-8c20-1c837d863aff.png)
