### PR TITLE
Preserve active features if visitors become users

### DIFF
--- a/lib/blackbeard.rb
+++ b/lib/blackbeard.rb
@@ -39,6 +39,7 @@ require "blackbeard/cohort"
 require "blackbeard/pirate"
 require 'blackbeard/chart'
 require 'blackbeard/cohort_data'
+require 'blackbeard/visitor_user_tracker'
 
 module Blackbeard
   class << self

--- a/lib/blackbeard/context.rb
+++ b/lib/blackbeard/context.rb
@@ -53,14 +53,25 @@ module Blackbeard
     end
 
     def user_id
+      if !visitor_id_from_cookie.nil?
+        VisitorUserTracker.set_visitor_id_for_user(user_id: @user.id, visitor_id: visitor_id_from_cookie)
+      end
+
+      vid = VisitorUserTracker.get_visitor_id_for_user(@user.id)
+      return vid if vid
       @user.id
     end
 
     def visitor_id
-      @visitor_id ||= (controller.request.cookies['bbd'] || generate_visitor_id).to_i
+      @visitor_id ||= (visitor_id_from_cookie || generate_visitor_id).to_i
     end
 
 private
+
+    def visitor_id_from_cookie
+      return nil if controller.nil? || controller.request.nil?
+      controller.request.cookies['bbd']
+    end
 
     def generate_visitor_id
       id = db.increment("visitor_id")

--- a/lib/blackbeard/visitor_user_tracker.rb
+++ b/lib/blackbeard/visitor_user_tracker.rb
@@ -1,0 +1,19 @@
+module Blackbeard
+  class VisitorUserTracker
+    include ConfigurationMethods
+
+    def self.get_visitor_id_for_user(user_id)
+      str_user_id = db.hash_get(hash_key, user_id)
+      str_user_id && str_user_id.to_i
+    end
+
+    def self.set_visitor_id_for_user(user_id:, visitor_id:)
+      db.hash_set(hash_key, user_id, visitor_id)
+    end
+
+    def self.hash_key
+      "visitor_user_trackers"
+    end
+
+  end
+end

--- a/spec/visitor_user_tracker_spec.rb
+++ b/spec/visitor_user_tracker_spec.rb
@@ -1,0 +1,32 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+module Blackbeard
+  describe VisitorUserTracker do
+    let(:user) { double(id: 42) }
+    let(:visitor_id) { 58 }
+
+    describe ".set_visitor_id_for_user" do
+      it "sets the visitor_id for the given user_id" do
+        described_class.set_visitor_id_for_user(user_id: user.id, visitor_id: visitor_id)
+        actual_visitor_id = described_class.get_visitor_id_for_user(user.id)
+        expect(actual_visitor_id).to eq(visitor_id)
+      end
+
+      context "when there is already a value for user_id" do
+        before do
+          hash_key = described_class.hash_key
+          allow(described_class.db).to receive(:hash_get).with(hash_key, user.id).and_return(visitor_id)
+        end
+
+        it "nopes. I mean, no-ops" do
+          described_class.get_visitor_id_for_user(user.id)
+          described_class.set_visitor_id_for_user(user_id: user.id,
+                                                  visitor_id: visitor_id)
+          expect(described_class.db).to_not receive(:hash_set)
+        end
+      end
+
+    end
+
+  end
+end


### PR DESCRIPTION
In order to preserve which features are active for a visitor when they become a user (either through login or signup), we need to record the value of their visitor id and associate it with their user id.

This is an approach to solve this problem, I created a `VistiorUserTracker`, which manages a redis hash from user_ids to visitor_ids. When a person first views the site without being logged in, we create a visitor id and store it as a cookie with key "bbd", this PR modifies `Context#user_id` so that if the user has a "bbd" cookie value, but there is no stored visitor id for them in redis, we record that.

The effect is that visitor_id is sticky, as soon as a user logs in or signs up, we record their visitor_id and then use that forever. Since we are storing the association in redis, we don't have to make any changes to the user model.
