### PR TITLE
Record which features were requested

### DIFF
--- a/lib/blackbeard/context.rb
+++ b/lib/blackbeard/context.rb
@@ -1,13 +1,14 @@
 module Blackbeard
   class Context
     include ConfigurationMethods
-    attr_reader :controller, :user
+    attr_reader :controller, :user, :requested_features
 
     def initialize(pirate, user, controller = nil)
       # TODO: remove pirate. access cache via separate cache class
       @pirate = pirate
       @controller = controller
       @user = user
+      @requested_features = {}
 
       if (@user == false) || (@user && guest_method && @user.send(guest_method) == false)
         @user = nil
@@ -45,7 +46,10 @@ module Blackbeard
     end
 
     def feature_active?(id, count_participation = true)
-      @pirate.feature(id.to_s).reload.active_for?(self, count_participation)
+      feature = @pirate.feature(id.to_s).reload
+      feature.active_for?(self, count_participation).tap { |result|
+        @requested_features.merge!(id.to_s => result)
+      }
     end
 
     def unique_identifier

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -105,6 +105,14 @@ module Blackbeard
         expect(inactive_feature).to receive(:active_for?).with(context, true).and_return(false)
         expect(context.feature_active?(:inactive_feature)).to be_falsey
       end
+
+      it 'adds the feature to the requested features' do
+        expect {
+          context.feature_active?(:active_feature)
+        }.to change {
+          context.requested_features.key?('active_feature')
+        }.from(false).to(true)
+      end
     end
 
   end


### PR DESCRIPTION
When a pirate context is asked about a features status, record the
feature and result into request_features.