### PR TITLE
Add some sleep and slice to hash_del_all

### DIFF
--- a/lib/blackbeard/feature.rb
+++ b/lib/blackbeard/feature.rb
@@ -78,9 +78,9 @@ module Blackbeard
       FeatureMetric.new(self,metric).metric_data
     end
 
-    def destroy_participant_data
-      active_participant_data.destroy
-      inactive_participant_data.destroy
+    def destroy_participant_data(**options)
+      active_participant_data.destroy(**options)
+      inactive_participant_data.destroy(**options)
     end
 
     private

--- a/lib/blackbeard/feature_participant_data.rb
+++ b/lib/blackbeard/feature_participant_data.rb
@@ -17,9 +17,9 @@ module Blackbeard
       db.hash_get(participants_hash_key, uid)
     end
 
-    def destroy
-      db.hash_del_all(hours_hash_key)
-      db.hash_del_all(participants_hash_key)
+    def destroy(**options)
+      db.hash_del_all(hours_hash_key, **options)
+      db.hash_del_all(participants_hash_key, **options)
     end
 
     private

--- a/spec/redis_store_spec.rb
+++ b/spec/redis_store_spec.rb
@@ -187,7 +187,7 @@ module Blackbeard
     it 'deletes the hash' do
       1.upto(1000).each {|f| db.hash_set(hash_key, f, true) }
       expect {
-        db.hash_del_all(hash_key, count: 10)
+        db.hash_del_all(hash_key, scan_count: 10)
       }.to change {
         db.exists(hash_key)
       }.from(true).to(false)


### PR DESCRIPTION
When deleting very large hashes we execute the scans fairly efficiently
however, the del commands are expensive and cause commands to stack up.
This renames count to scan_count and adds scan_sleep to control the
result size and speed of the hscan commands. It also adds del_count and
del_sleep. del_count will slice the results into small chunks for
deletion and then del_sleep controls speed.