### PR TITLE
Add App-Revisions gating to Blackbeard

### DIFF
--- a/dashboard/routes/revisions.rb
+++ b/dashboard/routes/revisions.rb
@@ -1,0 +1,23 @@
+module Blackbeard
+  module DashboardRoutes
+    class Revisions < Base
+      get '/revisions' do
+        @revisions = Revision.all
+        erb 'revisions/index'.to_sym
+      end
+
+      get '/revisions/:id' do
+        ensure_revision; ensure_charts
+        erb 'revisions/show'.to_sym
+      end
+
+      def ensure_revision
+        @revision = Revision.find(params[:id]) or pass
+      end
+
+      def ensure_charts
+        @charts = [@revision.recent_hours_chart, @revision.recent_days_chart]
+      end
+    end
+  end
+end

--- a/dashboard/views/layout.erb
+++ b/dashboard/views/layout.erb
@@ -37,6 +37,7 @@
             <li><a href="<%= url('features') %>">Features</a></li>
             <li><a href="<%= url('groups') %>">Groups</a></li>
             <li><a href="<%= url('metrics') %>">Metrics</a></li>
+            <li><a href="<%= url('revisions') %>">Revisions</a></li>
             <!-- li><a href="<%= url('tests') %>">Tests</a></li -->
           </ul>
         </div><!--/.nav-collapse -->

--- a/dashboard/views/revisions/index.erb
+++ b/dashboard/views/revisions/index.erb
@@ -1,0 +1,21 @@
+<div class="page-header">
+  <h1>Revisions</h1>
+  <p>Revisions are particular releases of the Goldstar API with gated functionality - you can tell when no clients are using a release when there are no `older` clients.</p>
+</div>
+
+<% if @revisions.any? %>
+<div class="panel panel-primary">
+  <div class="panel-heading">
+    <h3 class="panel-title">Queried Revisions</h3>
+  </div>
+  <ul class="list-group">
+  <% @revisions.each do |revision| %>
+  <li class="list-group-item"><a href="<%= url(revision.path) %>"><%= revision.name %></a></li>
+  <% end %>
+  </ul>
+</div>
+<% else %>
+  <div class="alert alert-danger">
+    <strong>No revisions!</strong> Something may be wrong or you may just need to define some revisions.
+  </div>
+<% end %>

--- a/dashboard/views/revisions/show.erb
+++ b/dashboard/views/revisions/show.erb
@@ -1,0 +1,5 @@
+<div class="page-header">
+  <h1><span id="editable-name"><%= h @revision.to_s %></span> <small>Revisions</small></h1>
+</div>
+
+<%= partial :'shared/charts', :locals => {:charts => @charts } %>

--- a/lib/blackbeard.rb
+++ b/lib/blackbeard.rb
@@ -25,20 +25,23 @@ require 'blackbeard/storable_has_set'
 require 'blackbeard/storable'
 require 'blackbeard/metric_data/base'
 require 'blackbeard/participant_methods'
-require "blackbeard/redis_store"
-require "blackbeard/group"
-require "blackbeard/context"
-require "blackbeard/metric"
-require "blackbeard/metric_data/unique"
-require "blackbeard/metric_data/total"
-require "blackbeard/test"
-require "blackbeard/errors"
-require "blackbeard/group"
-require "blackbeard/feature"
-require "blackbeard/cohort"
-require "blackbeard/pirate"
+require 'blackbeard/redis_store'
+require 'blackbeard/group'
+require 'blackbeard/context'
+require 'blackbeard/metric'
+require 'blackbeard/metric_data/unique'
+require 'blackbeard/metric_data/total'
+require 'blackbeard/test'
+require 'blackbeard/errors'
+require 'blackbeard/group'
+require 'blackbeard/feature'
+require 'blackbeard/cohort'
+require 'blackbeard/pirate'
 require 'blackbeard/chart'
 require 'blackbeard/cohort_data'
+require 'blackbeard/app_revision_participant_data'
+require 'blackbeard/revision'
+require 'blackbeard/app_revision'
 
 module Blackbeard
   class << self

--- a/lib/blackbeard/app_revision.rb
+++ b/lib/blackbeard/app_revision.rb
@@ -1,0 +1,45 @@
+module Blackbeard
+  class AppRevision
+    include ConfigurationMethods
+    include Comparable
+    include Chartable
+
+    OLDEST = "0.00"
+
+    attr_reader :comparable_revision, :context
+
+    def initialize(header_string, context = nil)
+      @context = context
+      @comparable_revision = git_revision_to_comparable(header_string)
+    end
+
+    def to_s
+      "#{comparable_revision.to_s}"
+    end
+
+    alias_method :key, :to_s
+
+    def <=>(target_revision)
+      target_version =  Blackbeard::AppRevision.new(target_revision)
+      gated = comparable_revision <=> target_version.comparable_revision
+      return gated unless context
+      target_version.revision.store_query(gated, context)
+      gated
+    end
+
+    def revision
+      @revision ||= Revision.find_or_create(key)
+    end
+
+    private
+
+    def git_revision_to_comparable(revision)
+      begin
+        Gem::Version.new(parse_revision(revision))
+      rescue ArgumentError
+        Gem::Version.new(OLDEST)
+      end
+    end
+
+  end
+end

--- a/lib/blackbeard/app_revision_participant_data.rb
+++ b/lib/blackbeard/app_revision_participant_data.rb
@@ -1,0 +1,44 @@
+module Blackbeard
+  class AppRevisionBaseParticipantData
+    include ConfigurationMethods
+    include ParticipantMethods
+
+    def initialize(revision)
+      @revision = revision
+    end
+
+    def add(uid, hour)
+      hour_id = hour_id(hour)
+      db.hash_increment_by(hours_hash_key, hour_id, 1)
+      db.hash_set(participants_hash_key, uid, status)
+    end
+
+    def last_status_for(uid)
+      db.hash_get(participants_hash_key, uid)
+    end
+
+    private
+
+    def key
+      @revision.to_s
+    end
+
+    def hours_hash_key
+      @hours_hash_key ||= "#{key}::#{status}::hours"
+    end
+
+  end
+
+  class AppRevisionNewerParticipantData < AppRevisionBaseParticipantData
+    def status
+      :newer
+    end
+  end
+
+  class AppRevisionOlderParticipantData < AppRevisionBaseParticipantData
+    def status
+      :older
+    end
+  end
+end
+

--- a/lib/blackbeard/configuration.rb
+++ b/lib/blackbeard/configuration.rb
@@ -1,7 +1,17 @@
 module Blackbeard
   class Configuration
-    attr_accessor :timezone, :namespace, :redis, :guest_method, :announcer
-    attr_reader :group_definitions
+    attr_accessor :timezone, :namespace, :redis, :guest_method, :announcer, :revision_header
+    attr_reader :group_definitions, :parse_revision_proc
+
+    DEFAULT_PARSE_REVISION_PROC = ->(rev) {
+      return '0.00' if rev.nil?
+
+      if String(rev)['.'].nil?
+        "#{rev}.00"
+      else
+        String(rev)
+      end
+    }
 
     def initialize
       @timezone = 'America/Los_Angeles'
@@ -9,6 +19,8 @@ module Blackbeard
       @group_definitions = {}
       @redis = nil
       @announcer = nil
+      @revision_header = nil
+      @parse_revision_proc = DEFAULT_PARSE_REVISION_PROC
     end
 
     def db
@@ -21,6 +33,10 @@ module Blackbeard
 
     def on_change(&block)
       @announcer = block
+    end
+
+    def to_parse_revision(&block)
+      @parse_revision_proc = block
     end
 
     def define_group(id, segments = nil, &block)

--- a/lib/blackbeard/configuration_methods.rb
+++ b/lib/blackbeard/configuration_methods.rb
@@ -20,5 +20,12 @@ module Blackbeard
       config.guest_method
     end
 
+    def revision_header
+      config.revision_header
+    end
+
+    def parse_revision(revision_number)
+      config.parse_revision_proc.call(revision_number)
+    end
   end
 end

--- a/lib/blackbeard/context.rb
+++ b/lib/blackbeard/context.rb
@@ -69,6 +69,14 @@ module Blackbeard
         end
     end
 
+    def app_revision
+      if controller.nil?
+        AppRevision.new('0', self)
+      else
+        AppRevision.new(controller.request.headers[revision_header], self)
+      end
+    end
+
     private
 
     def generate_visitor_id

--- a/lib/blackbeard/dashboard.rb
+++ b/lib/blackbeard/dashboard.rb
@@ -10,6 +10,7 @@ require 'routes/metrics'
 require 'routes/tests'
 require 'routes/features'
 require 'routes/cohorts'
+require 'routes/revisions'
 
 module Blackbeard
   class Dashboard < Sinatra::Base
@@ -23,5 +24,6 @@ module Blackbeard
     use DashboardRoutes::Groups
     use DashboardRoutes::Features
     use DashboardRoutes::Cohorts
+    use DashboardRoutes::Revisions
   end
 end

--- a/lib/blackbeard/pirate.rb
+++ b/lib/blackbeard/pirate.rb
@@ -62,6 +62,11 @@ module Blackbeard
       @set_context.ab_test(id, options)
     end
 
+    def app_revision
+      return AppRevision.new('0', self) unless @set_context
+      @set_context.app_revision
+    end
+
     def feature_active?(id, count_participation = true)
       return false unless @set_context
       @set_context.feature_active?(id, count_participation = true)

--- a/lib/blackbeard/redis_store.rb
+++ b/lib/blackbeard/redis_store.rb
@@ -7,6 +7,18 @@ module Blackbeard
       @redis = Redis::Namespace.new(namespace.to_sym, :redis => r)
     end
 
+    def keys
+      iter = nil
+      all_keys = []
+
+      while iter != '0'
+        iter, keys = redis.scan(iter || 0, count: 1000)
+        all_keys += keys
+      end
+
+      all_keys
+    end
+
     # Hash commands
     def hash_set_if_not_exists(hash_key, field, value)
       redis.hsetnx(hash_key, field, value)

--- a/lib/blackbeard/revision.rb
+++ b/lib/blackbeard/revision.rb
@@ -1,0 +1,43 @@
+module Blackbeard
+  class Revision < Storable
+    include Chartable
+
+    set_master_key :revisions
+    string_attributes :name
+
+    def to_s
+      id
+    end
+
+    def store_query(result, context)
+      revision_data = result >= 0 ? newer_revision_data : older_revision_data
+      revision_data.add(context.unique_identifier, tz.now)
+    end
+
+    def older_revision_data
+      @older_data ||= AppRevisionOlderParticipantData.new(self)
+    end
+
+    def newer_revision_data
+      @newer_data ||= AppRevisionNewerParticipantData.new(self)
+    end
+
+    def chartable_segments
+      ['older_revisions', 'newer_revisions']
+    end
+
+    def chartable_result_for_hour(hour)
+      {
+        'older_revisions' => older_revision_data.participants_for_hour(hour),
+        'newer_revisions' => newer_revision_data.participants_for_hour(hour)
+      }
+    end
+
+    def chartable_result_for_day(date)
+      {
+        'older_revisions' => older_revision_data.participants_for_day(date),
+        'newer_revisions' => newer_revision_data.participants_for_day(date)
+      }
+    end
+  end
+end

--- a/lib/blackbeard/version.rb
+++ b/lib/blackbeard/version.rb
@@ -1,3 +1,3 @@
 module Blackbeard
-  VERSION = "0.0.5.3"
+  VERSION = "0.1.0.0"
 end

--- a/spec/app_revision_participant_data_spec.rb
+++ b/spec/app_revision_participant_data_spec.rb
@@ -1,0 +1,41 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+module Blackbeard
+  describe "FeatureParticipantData" do
+    let(:feature) { AppRevision.new('20170912') }
+    let(:hour) { Time.now }
+
+    describe AppRevisionNewerParticipantData do
+      let(:data) { AppRevisionNewerParticipantData.new(feature) }
+
+      describe "#add" do
+        it "should increment the participants for the hour" do
+          expect{
+            data.add('bob', hour)
+          }.to change{ data.participants_for_hour(hour) }.by(1)
+        end
+        it "should set the value of the participant to active" do
+          expect{
+            data.add('bob', hour)
+          }.to change{ data.value_for_participant('bob') }.from(nil).to("newer")
+        end
+      end
+    end
+
+    describe AppRevisionOlderParticipantData do
+      let(:data) { AppRevisionOlderParticipantData.new(feature) }
+      describe "#add" do
+        it "should increment the participants for the hour" do
+          expect{
+            data.add('bob', hour)
+          }.to change{ data.participants_for_hour(hour) }.by(1)
+        end
+        it "should set the value of the participant to active" do
+          expect{
+            data.add('bob', hour)
+          }.to change{ data.value_for_participant('bob') }.from(nil).to("older")
+        end
+      end
+    end
+  end
+end

--- a/spec/app_revision_spec.rb
+++ b/spec/app_revision_spec.rb
@@ -1,0 +1,146 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+module Blackbeard
+  describe AppRevision do
+    # App Built on September 15th
+    let(:pirate)  { Pirate.new }
+    let(:user)    { double(:id => 1) }
+    let(:context) { Context.new(pirate, user) }
+    subject(:revision) { described_class.new('20110915', context) }
+
+    it 'should initialize with string' do
+      expect(revision.to_s).to eq '20110915.00'
+    end
+
+    context 'when passed an invalid string' do
+      subject(:revision) { described_class.new('MONKEYS') }
+
+      it 'defaults to the oldest revision' do
+        expect(revision.to_s).to eq '0.00'
+      end
+    end
+
+    describe 'should compare with similarly formatted version strings' do
+      context 'when less' do
+        it 'returns true for greater than' do
+          # Api Changed on Sept 14th - release 7 - client should see this feature
+          # expect(revision).to receive(:newer_participant_data).and_call_original
+          expect(revision > '20110914.07').to be true
+        end
+      end
+
+      context 'when equal' do
+        it 'returns true for equal' do
+          # Api Changed on Sept 15th - release 0 - client should see this feature
+          # expect(revision).to receive(:newer_participant_data).and_call_original
+          expect(revision == '20110915.00').to be true
+        end
+      end
+
+      context 'when more' do
+        it 'returns true for less' do
+          # Api Changed on Sept 15th - release 1 - client should NOT see this feature
+          # expect(revision).to receive(:older_participant_data).and_call_original
+          expect(revision < '20110915.01').to be true
+        end
+      end
+
+      context 'when compared with nonsense' do
+        it 'is less than' do
+          # Client Revision isn't valid - client will NOT see feature
+          # note that this is backwards of the actual use case of this feature
+          # it's unlikely that you would type in an invalid revision
+          expect(revision > 'MONKEYS').to be true
+          expect(revision < 'MONKEYS').to be false
+          expect(revision == 'MONKEYS').to be false
+        end
+      end
+    end
+
+    def hour_id(time)
+      time.strftime("%Y%m%d%H")
+    end
+
+    describe 'it record query information in the metrics collector' do
+      let(:one_day_older) { described_class.new('20150913', context) }
+      let(:two_days_older) { described_class.new('20150912', context) }
+      let(:three_days_older) { described_class.new('20150911', context) }
+
+      context 'when less' do
+        it 'records queries in the "older" bucket' do
+          one_day_older > 20150914.01
+          two_days_older > 20150914.01
+          three_days_older > 20150914.01
+
+
+          # This is a little confusing - the left side is the _clients_
+          # requested revision, and the right side is the revision you are
+          # querying against - we store the metrics under "target revision" on
+          # the RHS - each unique revision requested by a client will increment
+          # the number of older requested revisions in a a given hour - since
+          # these all happeend like _just now_ we'll see this as being this
+          # hours value being 3 - meaning that 3 different client versions
+          # were queried against this API version.
+
+          hours_key = Blackbeard::Revision.find('20150914.01').older_revision_data.send(:hours_hash_key)
+          expect(Blackbeard.config.db.hash_get_all(hours_key)).to eq({
+            hour_id(Blackbeard.config.tz.now) => "3"
+          })
+        end
+      end
+    end
+
+    describe 'it is an argument error if the "hard" revision comes first' do
+      let(:one_day_older) { described_class.new('20150913', context) }
+
+      context 'when does not matter' do
+        it 'throws an argument error' do
+          expect { 20140915.01 > one_day_older }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    describe 'comparisons work and it puts them in the right bucket' do
+      let(:one_day_newer) { described_class.new('20150915', context) }
+      let(:one_day_older) { described_class.new('20150913', context) }
+      let(:three_days_newer) { described_class.new('20150917', context) }
+
+      it 'records them in the right bucket regardless of which way the arrow faces' do
+        expect(one_day_older > 20150914.01).to be false
+        expect(one_day_newer < 20150914.01).to be false
+        expect(three_days_newer > 20150914.01).to be true
+
+        hours_key = Blackbeard::Revision.find('20150914.01').older_revision_data.send(:hours_hash_key)
+          expect(Blackbeard.config.db.hash_get_all(hours_key)).to eq({
+            hour_id(Blackbeard.config.tz.now) => "1"
+          })
+
+        hours_key = Blackbeard::Revision.find('20150914.01').newer_revision_data.send(:hours_hash_key)
+          expect(Blackbeard.config.db.hash_get_all(hours_key)).to eq({
+            hour_id(Blackbeard.config.tz.now) => "2"
+          })
+      end
+    end
+
+
+    describe 'it record query information in the metrics collector' do
+      let(:one_day_newer) { described_class.new('20150915', context) }
+      let(:two_days_newer) { described_class.new('20150916', context) }
+      let(:three_days_newer) { described_class.new('20150917', context) }
+
+      context 'when less' do
+        it 'records queries in the "older" bucket' do
+          one_day_newer > 20150914.01
+          two_days_newer > 20150914.01
+          three_days_newer > 20150914.01
+
+          hours_key = Blackbeard::Revision.find('20150914.01').newer_revision_data.send(:hours_hash_key)
+          expect(Blackbeard.config.db.hash_get_all(hours_key)).to eq({
+            hour_id(Blackbeard.config.tz.now) => "3"
+          })
+        end
+      end
+    end
+
+  end
+end

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -105,6 +105,39 @@ module Blackbeard
       end
     end
 
+    describe '#app_revision' do
+
+      context 'when not in a controller context' do
+        subject(:context) { Context.new(pirate, user) }
+
+        it 'returns a zero app revision' do
+          expect(context.app_revision).to eq '0'
+        end
+      end
+
+      context 'when in an controller context' do
+        let(:header) { { 'X-App-Revision' => '20170911' } }
+        let(:controller) { double(request: double(headers: header)) }
+
+        before do
+          # you set this in configuration - we stub it here for ease - it will
+          # _always_ return revision 0 (old as shit or unknown) if it's not set
+          expect(context).to receive(:revision_header).and_return('X-App-Revision')
+        end
+
+        subject(:context) { Context.new(pirate, user, controller) }
+
+        it 'returns an app revision equal to the header' do
+          # the `to eq` expectation doesn't do quite what we want here.
+          expect(context.app_revision == '20170911.00').to be true
+        end
+      end
+
+      it 'should return an app_revision floatish' do
+        expect(context.app_revision).to be_an_instance_of(Blackbeard::AppRevision)
+      end
+    end
+
     describe "#feature_active?" do
       let(:inactive_feature) { Blackbeard::Feature.create(:inactive_feature) }
       let(:active_feature) { Blackbeard::Feature.create(:active_feature) }

--- a/spec/dashboard/revisions_spec.rb
+++ b/spec/dashboard/revisions_spec.rb
@@ -1,0 +1,32 @@
+require File.expand_path(File.dirname(__FILE__) + './../spec_helper')
+
+require 'rack/test'
+require 'blackbeard/dashboard'
+
+module Blackbeard
+  describe Dashboard do
+    include Rack::Test::Methods
+
+    let(:app) { Dashboard }
+
+    describe "get /revisions" do
+      it "should list all the groups" do
+        Revision.create('20170912')
+        get "/revisions"
+
+        expect(last_response).to be_ok
+        expect(last_response.body).to include('revisions')
+      end
+    end
+
+    describe "get /revisions/:id" do
+      it "should show a metric" do
+        revision = Revision.create("20170912")
+        get "/revisions/#{revision.id}"
+
+        expect(last_response).to be_ok
+        expect(last_response.body).to include("20170912")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What changes does this PR introduce?

This adds App-Revision queries to Blackbeard - allowing you to to selectively turn off properties and see how many unique clients are still requesting API revisions that include those properties.

#### Is a QA+2 needed?

Probably just smoke-test - not in use in Goldstar yet though.

## Any background context you want to provide?

Recently we added HTML support to a certain field in the API - older clients don't support HTML in this field - which leaves us in the sort of unfortunate position of not being able to USE the HTML support that we have.  This is sort of an ongoing problem in that we have lots of fields that we're not exactly sure if they are in use or not - or properties where the format should change.

The way to use this is like so:

In your representer / client / controller context.

```ruby
if $pirate.app_revision > 20150911.07
    "... <do something for new clients> ... "
else
   "... <do something for old clients> ..."
end
```

## Where should the reviewer start?

Way easier to understand this in action than in theory - you should try it out on your local machine.

## Has this been manually tested? How?

Locally.

## What are the relevant tickets?

https://trello.com/c/JB3Na6wu

## What GIF best describes this PR or how it makes you feel?

![oh yes](https://media.giphy.com/media/3oEhmORQWRNufialMs/giphy.gif "i refuse to use the ron paul it's happening gif")

## Do you have UI changes to show?

http://recordit.co/2JBEofZLvo