### PR TITLE
Pass only Context or nil to AppRevision

### DIFF
--- a/lib/blackbeard/pirate.rb
+++ b/lib/blackbeard/pirate.rb
@@ -63,7 +63,7 @@ module Blackbeard
     end
 
     def app_revision
-      return AppRevision.new('0', self) unless @set_context
+      return AppRevision.new('0') unless @set_context
       @set_context.app_revision
     end
 

--- a/lib/blackbeard/version.rb
+++ b/lib/blackbeard/version.rb
@@ -1,3 +1,3 @@
 module Blackbeard
-  VERSION = "0.1.0.0"
+  VERSION = "0.1.0.1"
 end


### PR DESCRIPTION
I found one!  An error that a type-checker would have caught.

The second parameter to a clients AppRevision should always be the Context - in this case we accidentally passed a Pirate to hit, which made AppRevision comparisons fail in test or other places where the context might not be set.