### PR TITLE
Return a thread local memoized pirate

### DIFF
--- a/lib/blackbeard.rb
+++ b/lib/blackbeard.rb
@@ -60,10 +60,9 @@ module Blackbeard
     end
 
     def pirate
-      yield(config) if block_given?
-      Blackbeard::Pirate.new
+      Thread.current[:blackbeard_pirate] ||= Blackbeard::Pirate.new
     end
   end
 end
 
-Blackbeard.pirate {}
+Blackbeard.configure! {}

--- a/spec/blackbeard_spec.rb
+++ b/spec/blackbeard_spec.rb
@@ -6,14 +6,24 @@ describe Blackbeard do
   end
 
   describe "pirate" do
-    it "can configure" do
-      p = Blackbeard.pirate do |config|
+    it 'is memoized within the same thread' do
+      expect(Blackbeard.pirate).to equal(Blackbeard.pirate)
+    end
+
+    it 'is unique across threads' do
+      expect(Blackbeard.pirate).to_not equal(Thread.new{Blackbeard.pirate}.value)
+    end
+  end
+
+  describe '#configure!' do
+    after { Blackbeard.configure! {} }
+
+    it "sets the values as expected" do
+      Blackbeard.configure! do |config|
         config.timezone = 'America/Somewhere'
       end
+
       expect(Blackbeard.config.timezone).to eq('America/Somewhere')
-    end
-    it "returns a pirate" do
-        expect(Blackbeard.pirate).to be_a(Blackbeard::Pirate)
     end
   end
 


### PR DESCRIPTION
When calling Blackbeard.pirate return a thread lcoal memoized pirate.
Removes the block from the pirate method to simplify the API.

Note: In our apps we set `$pirate` to `Blackbeard.pirate {...}`  This will be required to change to `Blackbeard.configure! {...}` and all instances of `$pirate` replaced with `Blackbeard.pirate`