### PR TITLE
Allow method reset of Thread local

### DIFF
--- a/lib/blackbeard.rb
+++ b/lib/blackbeard.rb
@@ -62,6 +62,10 @@ module Blackbeard
     def pirate
       Thread.current[:blackbeard_pirate] ||= Blackbeard::Pirate.new
     end
+
+    def walk_the_plank!
+      Thread.current[:blackbeard_pirate] = nil
+    end
   end
 end
 


### PR DESCRIPTION
There's no reason to use the same Pirate::Context for the entire life time of the unicorn worker - this let's us force it to nil so it will be reconstituted.